### PR TITLE
feat: add Amp CLI adapter for Sourcegraph Amp support

### DIFF
--- a/packages/cli/src/adapters/AMP_ADAPTER.md
+++ b/packages/cli/src/adapters/AMP_ADAPTER.md
@@ -1,0 +1,136 @@
+# Amp CLI Adapter
+
+This document describes the Amp CLI adapter implementation and feature parity analysis compared to the Claude CLI adapter.
+
+## Overview
+
+The Amp CLI adapter enables Ralph to use [Sourcegraph Amp](https://ampcode.com) as the underlying AI coding agent. Amp supports **Claude Code compatible stream-json output format**, which means the existing stream-json parser works seamlessly with Amp output.
+
+## Installation
+
+Amp CLI can be installed via npm/pnpm/yarn:
+
+```bash
+pnpm add -g @sourcegraph/amp
+npm install -g @sourcegraph/amp
+yarn global add @sourcegraph/amp
+```
+
+**Requirements:** Node.js v22 or higher
+
+## Configuration
+
+To use the Amp adapter, set it in your Ralph config:
+
+```toml
+# ~/.ralph/config.toml or .ralph/config.toml
+adapter = "amp"
+```
+
+Or use it directly with the CLI:
+
+```bash
+ralph run --adapter amp "your prompt here"
+```
+
+## Feature Parity Analysis
+
+### Full Parity Features
+
+| Feature | Claude CLI | Amp CLI | Status |
+|---------|-----------|---------|--------|
+| Stream JSON output | `--output-format stream-json` | `--stream-json` | ✅ Full parity |
+| Tool use blocks | Supported | Supported | ✅ Full parity |
+| Tool result blocks | Supported | Supported | ✅ Full parity |
+| Text deltas (streaming) | Supported | Supported | ✅ Full parity |
+| Message parsing | StreamJsonParser | StreamJsonParser | ✅ Full parity |
+| Verbose/Debug mode | `--verbose` / `--debug` | `--log-level debug` | ✅ Full parity |
+| Non-interactive mode | `-p <prompt>` | `--execute <prompt>` | ✅ Full parity |
+
+### Partial Parity Features
+
+| Feature | Claude CLI | Amp CLI | Notes |
+|---------|-----------|---------|-------|
+| Permission mode | `--permission-mode acceptEdits` | `--dangerously-allow-all` | Different API, same effect |
+| Session/Thread ID | `session_id` field | `session_id` field (via thread) | Amp uses "threads" terminology |
+
+### Amp-Specific Features (Not in Claude)
+
+| Feature | Description |
+|---------|-------------|
+| **Thread Management** | `amp threads new/continue/fork/list/share/compact` |
+| **Subagents** | Librarian (codebase analysis), Oracle (expert advice), Smart (primary coding) |
+| **Thread Visibility** | `--visibility private/public/workspace/group` |
+| **MCP Servers** | Built-in MCP server management via `amp mcp` commands |
+| **Custom Toolboxes** | User-defined tools via `AMP_TOOLBOX` directory |
+| **Command Allowlisting** | Per-project CLI command security rules |
+| **Sound Notifications** | `--notifications` / `--no-notifications` |
+
+### Claude-Specific Features (Not in Amp)
+
+| Feature | Description |
+|---------|-------------|
+| **Permission Modes** | Fine-grained permission control (`acceptEdits`, etc.) |
+| **Resume Sessions** | `--resume <session_id>` flag for session continuation |
+
+## Functional Gaps
+
+### 1. Thread/Session Management
+
+**Gap:** Ralph's iteration loop uses `sessionId` from Claude's stream-json output for session continuity. Amp uses "threads" with different management commands.
+
+**Impact:** Session persistence between iterations may work via stream-json `session_id` field, but dedicated thread management features are not exposed.
+
+**Workaround:** Amp's `--stream-json` output includes `session_id` in result messages, so basic session tracking works.
+
+### 2. Permission Model
+
+**Gap:** Claude uses `--permission-mode acceptEdits` for controlled permission bypass. Amp uses `--dangerously-allow-all` which bypasses all prompts.
+
+**Impact:** Less granular control in Amp adapter. For production use, consider configuring `amp permissions` instead.
+
+**Workaround:** Configure Amp's permission rules via `amp permissions add` for more controlled access.
+
+### 3. Session Resume
+
+**Gap:** Claude supports `--resume <session_id>` to continue a previous session. Amp uses thread commands (`amp threads continue`).
+
+**Impact:** Ralph's session resume functionality may not work identically with Amp.
+
+**Workaround:** Use Amp's thread management commands directly for session continuation.
+
+## TUI Compatibility
+
+The Amp adapter is fully compatible with Ralph's TUI (Terminal User Interface) because:
+
+1. **Stream JSON Format:** Amp's `--stream-json` output is Claude Code compatible
+2. **Message Types:** All message types (tool use, tool result, text delta, etc.) parse correctly
+3. **Rich Display:** Tool invocations, results, and streaming text display properly
+4. **Progress Tracking:** Session ID and completion status are extracted from result messages
+
+## CLI Arguments Mapping
+
+| Ralph Option | Claude Args | Amp Args |
+|--------------|-------------|----------|
+| Base command | `claude` | `amp --execute` |
+| Permission bypass | `--permission-mode acceptEdits` | `--dangerously-allow-all` |
+| Stream JSON | `--output-format stream-json --verbose` | `--stream-json` |
+| Verbose | `--debug` | `--log-level debug` |
+| Prompt | `-p <prompt>` | `<prompt>` (positional) |
+| Notifications | N/A | `--no-notifications` |
+
+## Environment Variables
+
+| Variable | Purpose |
+|----------|---------|
+| `AMP_API_KEY` | Authentication token |
+| `AMP_URL` | Override server endpoint |
+| `AMP_LOG_LEVEL` | Set logging verbosity |
+| `AMP_SETTINGS_FILE` | Custom settings location |
+
+## References
+
+- [Amp Official Site](https://ampcode.com)
+- [Amp Owner's Manual](https://ampcode.com/manual)
+- [Amp CLI npm package](https://www.npmjs.com/package/@sourcegraph/amp)
+- [Streaming JSON announcement](https://ampcode.com/news/streaming-json)

--- a/packages/cli/src/adapters/amp.ts
+++ b/packages/cli/src/adapters/amp.ts
@@ -1,0 +1,73 @@
+import type { OutputFormat } from "#parsers";
+import { isCommandAvailable } from "#utils/stream";
+import type { AdapterOptions, CLIAdapter } from "./types";
+
+/**
+ * Adapter for Sourcegraph Amp CLI (https://ampcode.com)
+ *
+ * Amp CLI supports Claude Code compatible stream-json output format via the
+ * --stream-json flag, providing full feature parity for message parsing.
+ *
+ * Key differences from Claude CLI:
+ * - Uses --execute/-x flag for non-interactive mode (vs -p for Claude)
+ * - Uses --dangerously-allow-all for permission bypass (vs --permission-mode for Claude)
+ * - Uses "threads" instead of "sessions" for conversation management
+ * - Has built-in subagents: Librarian (codebase analysis), Oracle (expert advice), Smart (primary)
+ *
+ * Thread management (not directly supported in this adapter):
+ * - amp threads new/continue/fork/list/share/compact
+ *
+ * @see https://ampcode.com/manual for full documentation
+ */
+export class AmpAdapter implements CLIAdapter {
+  readonly name = "amp";
+
+  /**
+   * Amp uses the same stream-json format as Claude Code, so we use the same
+   * completion marker. The result message with type "result" indicates completion.
+   */
+  readonly completionMarker = "<promise>COMPLETE</promise>";
+
+  /**
+   * Amp supports Claude Code compatible stream-json format via --stream-json flag.
+   * Text mode works with --execute flag for simple output.
+   */
+  readonly supportedFormats: OutputFormat[] = ["stream-json", "text"];
+
+  buildArgs(prompt: string, options: AdapterOptions): string[] {
+    const args = ["amp"];
+
+    // Execute mode is required for non-interactive CLI usage
+    args.push("--execute");
+
+    // Enable permission bypass for automated operation (equivalent to Claude's acceptEdits)
+    // Note: In production, you may want to configure this via amp permissions instead
+    args.push("--dangerously-allow-all");
+
+    // Enable stream-json output for rich message parsing
+    if (options.outputFormat === "stream-json") {
+      args.push("--stream-json");
+    }
+
+    // Map verbose flag to debug log level
+    if (options.verbose) {
+      args.push("--log-level", "debug");
+    }
+
+    // Disable sound notifications in CLI mode
+    args.push("--no-notifications");
+
+    // The prompt is passed as the execute message argument
+    args.push(prompt);
+
+    return args;
+  }
+
+  detectCompletion(output: string): boolean {
+    return output.includes(this.completionMarker);
+  }
+
+  async isAvailable(): Promise<boolean> {
+    return isCommandAvailable(this.name);
+  }
+}

--- a/packages/cli/src/adapters/index.ts
+++ b/packages/cli/src/adapters/index.ts
@@ -1,9 +1,11 @@
 import type { AdapterType } from "#config/schema";
+import { AmpAdapter } from "./amp";
 import { ClaudeAdapter } from "./claude";
 import { OpenCodeAdapter } from "./opencode";
 import type { CLIAdapter } from "./types";
 
 const adapters: Record<AdapterType, () => CLIAdapter> = {
+  amp: () => new AmpAdapter(),
   claude: () => new ClaudeAdapter(),
   opencode: () => new OpenCodeAdapter(),
 };

--- a/packages/cli/src/config/schema.ts
+++ b/packages/cli/src/config/schema.ts
@@ -1,6 +1,6 @@
 import { z } from "zod";
 
-export const AdapterType = z.enum(["claude", "opencode"]);
+export const AdapterType = z.enum(["amp", "claude", "opencode"]);
 export type AdapterType = z.infer<typeof AdapterType>;
 
 export const ConfigSchema = z.object({


### PR DESCRIPTION
Add adapter for Sourcegraph Amp CLI (ampcode.com) with full stream-json
compatibility. Amp's --stream-json flag outputs Claude Code compatible
format, enabling seamless integration with existing parsers and TUI.

Key features:
- Stream JSON output support via --stream-json flag
- Execute mode (--execute) for non-interactive operation
- Permission bypass via --dangerously-allow-all
- Debug logging via --log-level debug

Includes comprehensive documentation (AMP_ADAPTER.md) covering:
- Feature parity analysis with Claude adapter
- Functional gaps and workarounds
- CLI argument mappings
- Amp-specific features (threads, subagents, MCP)