### PR TITLE
Add ⥁ (clockwise closed circle arrow) as Ralph icon

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,6 @@
-# ralph
+# ⥁ ralph
 
-<p align="center">
-  <img src="docs/public/favicon.svg" alt="ralph logo" width="80" height="80">
-</p>
+<h1 align="center">⥁</h1>
 
 <p align="center">
   <strong>AI-agnostic agentic loop CLI</strong>
@@ -68,10 +66,10 @@ ralph run --prompt TASK.md
 
 ## Features
 
-- **🔄 Context Reset** — Fresh context window each iteration
-- **🧠 State Persistence** — Progress via git, files, and tests
-- **🛑 Smart Exit** — Configurable completion conditions
-- **🔧 Tool Agnostic** — Claude Code, OpenCode, Aider, or any CLI
+- **⥁ Context Reset** — Fresh context window each iteration
+- **⥁ State Persistence** — Progress via git, files, and tests
+- **⥁ Smart Exit** — Configurable completion conditions
+- **⥁ Tool Agnostic** — Claude Code, OpenCode, Aider, or any CLI
 
 ## How It Works
 

--- a/packages/cli/src/global.ts
+++ b/packages/cli/src/global.ts
@@ -5,6 +5,9 @@ import { xdgCache, xdgConfig, xdgData, xdgState } from "xdg-basedir";
 
 const app = "ralph";
 
+/** Ralph icon - clockwise closed circle arrow (U+2941) */
+export const RALPH_ICON = "⥁";
+
 const data = path.join(xdgData!, app);
 const cache = path.join(xdgCache!, app);
 const config = path.join(xdgConfig!, app);

--- a/packages/cli/src/ui/ralph-app.tsx
+++ b/packages/cli/src/ui/ralph-app.tsx
@@ -8,6 +8,7 @@ import {
   Show,
 } from "solid-js";
 import type { AdapterResult, CLIAdapter } from "#adapters/types";
+import { RALPH_ICON } from "#global";
 import { createParser, type OutputFormat, type ParsedChunk } from "#parsers";
 import type { RichMessage } from "#parsers/message-types";
 import { MessageList } from "#ui/components/message-list";
@@ -279,7 +280,7 @@ function RalphApp(props: RalphAppProps) {
       }
 
       setIteration(i);
-      setTerminalTitle(`Ralph: ${i}/${props.maxIterations}`);
+      setTerminalTitle(`${RALPH_ICON} Ralph: ${i}/${props.maxIterations}`);
       setLegacyOutput((prev) => [
         ...prev.slice(-OUTPUT_BUFFER_SIZE),
         `--- Iteration ${i}/${props.maxIterations} ---`,
@@ -346,6 +347,7 @@ function RalphApp(props: RalphAppProps) {
     <box flexDirection="column" style={{ padding: 1 }}>
       <box>
         <text>
+          <span style={{ fg: "#00aaff" }}>{RALPH_ICON}</span>{" "}
           <strong>Ralph Agent Loop</strong>
           <span style={{ fg: "#666666" }}>
             {" "}


### PR DESCRIPTION
Use U+2941 as the brand icon throughout:
- Add RALPH_ICON constant in global.ts
- Display icon in TUI header with cyan color
- Show icon in terminal title during iterations
- Update README header and features section