### PR TITLE
Add summary output to ralph process

### DIFF
--- a/packages/cli/src/commands/run.ts
+++ b/packages/cli/src/commands/run.ts
@@ -7,6 +7,12 @@ import { getPrdPath, getPromptPath, loadConfig } from "#config/loader";
 import type { Hooks } from "#config/schema";
 import { createHookExecutor } from "#hooks";
 import { createParser, type OutputFormat } from "#parsers";
+import type { ResultMessage } from "#parsers/message-types";
+import {
+  isMessage,
+  isResultMessage,
+  isToolUseBlock,
+} from "#parsers/message-types";
 import type { Prd } from "#schema/prd";
 import type { LoopResult } from "#ui/ralph-app";
 import { runLoopTUI } from "#ui/ralph-app";
@@ -122,6 +128,10 @@ async function runLoopPlain(options: RunLoopPlainOptions): Promise<LoopResult> {
   let iterations = 0;
   let exitReason: LoopResult["exitReason"] = "max_iterations";
   let lastSessionId: string | undefined;
+  let totalInputTokens = 0;
+  let totalOutputTokens = 0;
+  let totalCost = 0;
+  let toolCallCount = 0;
 
   // Initialize hook executor if hooks provided
   const hookExecutor = hooks
@@ -172,11 +182,29 @@ async function runLoopPlain(options: RunLoopPlainOptions): Promise<LoopResult> {
     const stdoutReader = stdout.getReader();
     const stderrReader = stderr.getReader();
 
+    // biome-ignore lint/complexity/noExcessiveCognitiveComplexity: stream processing requires nested conditionals
     const handleText = (text: string) => {
       const chunks = parser.processChunk(text);
       for (const chunk of chunks) {
         if (chunk.displayText) {
           process.stdout.write(`${chunk.displayText}\n`);
+        }
+        // Track tool calls and token usage
+        if (chunk.richMessage) {
+          if (isMessage(chunk.richMessage)) {
+            const toolCalls = chunk.richMessage.content.filter(isToolUseBlock);
+            toolCallCount += toolCalls.length;
+          }
+          if (isResultMessage(chunk.richMessage)) {
+            const result = chunk.richMessage as ResultMessage;
+            if (result.usage) {
+              totalInputTokens += result.usage.input_tokens;
+              totalOutputTokens += result.usage.output_tokens;
+            }
+            if (result.total_cost_usd !== undefined) {
+              totalCost += result.total_cost_usd;
+            }
+          }
         }
       }
     };
@@ -196,6 +224,23 @@ async function runLoopPlain(options: RunLoopPlainOptions): Promise<LoopResult> {
     for (const chunk of finalChunks) {
       if (chunk.displayText) {
         process.stdout.write(`${chunk.displayText}\n`);
+      }
+      // Track tool calls and token usage from final chunks
+      if (chunk.richMessage) {
+        if (isMessage(chunk.richMessage)) {
+          const toolCalls = chunk.richMessage.content.filter(isToolUseBlock);
+          toolCallCount += toolCalls.length;
+        }
+        if (isResultMessage(chunk.richMessage)) {
+          const result = chunk.richMessage as ResultMessage;
+          if (result.usage) {
+            totalInputTokens += result.usage.input_tokens;
+            totalOutputTokens += result.usage.output_tokens;
+          }
+          if (result.total_cost_usd !== undefined) {
+            totalCost += result.total_cost_usd;
+          }
+        }
       }
     }
 
@@ -237,7 +282,89 @@ async function runLoopPlain(options: RunLoopPlainOptions): Promise<LoopResult> {
     await hookExecutor.executeRalphMaxIterations(iterations);
   }
 
-  return { iterations, exitReason, lastExitCode, lastSessionId };
+  return {
+    iterations,
+    exitReason,
+    lastExitCode,
+    lastSessionId,
+    totalInputTokens,
+    totalOutputTokens,
+    totalCost,
+    toolCallCount,
+  };
+}
+
+function formatTokens(count: number): string {
+  if (count >= 1000) {
+    return `${(count / 1000).toFixed(1)}k`;
+  }
+  return count.toString();
+}
+
+function formatCost(cost: number): string {
+  if (cost < 0.01) {
+    return `$${cost.toFixed(4)}`;
+  }
+  return `$${cost.toFixed(2)}`;
+}
+
+function getOutcomeIcon(exitReason: LoopResult["exitReason"]): string {
+  if (exitReason === "complete") {
+    return "\u2713";
+  }
+  if (exitReason === "error" || exitReason === "user_abort") {
+    return "\u2717";
+  }
+  return "\u26A0";
+}
+
+function getOutcomeLabel(exitReason: LoopResult["exitReason"]): string {
+  if (exitReason === "complete") {
+    return "Task completed successfully";
+  }
+  if (exitReason === "error") {
+    return "Task failed with error";
+  }
+  if (exitReason === "user_abort") {
+    return "Task aborted by user";
+  }
+  return "Reached maximum iterations";
+}
+
+function printSummary(result: LoopResult): void {
+  console.log(`\n${"=".repeat(50)}`);
+  console.log("                    SUMMARY");
+  console.log("=".repeat(50));
+
+  const outcomeIcon = getOutcomeIcon(result.exitReason);
+  const outcomeLabel = getOutcomeLabel(result.exitReason);
+
+  console.log(`\n  Outcome:     ${outcomeIcon} ${outcomeLabel}`);
+  console.log(`  Iterations:  ${result.iterations}`);
+
+  if (result.toolCallCount !== undefined && result.toolCallCount > 0) {
+    console.log(`  Tool calls:  ${result.toolCallCount}`);
+  }
+
+  const hasTokenData =
+    (result.totalInputTokens && result.totalInputTokens > 0) ||
+    (result.totalOutputTokens && result.totalOutputTokens > 0);
+
+  if (hasTokenData) {
+    console.log(
+      `  Tokens:      ${formatTokens(result.totalInputTokens || 0)} in / ${formatTokens(result.totalOutputTokens || 0)} out`
+    );
+  }
+
+  if (result.totalCost !== undefined && result.totalCost > 0) {
+    console.log(`  Total cost:  ${formatCost(result.totalCost)}`);
+  }
+
+  if (result.lastSessionId) {
+    console.log(`  Session:     ${result.lastSessionId}`);
+  }
+
+  console.log(`\n${"=".repeat(50)}`);
 }
 
 export const runCommand: CommandModule<object, RunArgs> = {
@@ -373,6 +500,7 @@ export const runCommand: CommandModule<object, RunArgs> = {
       });
     }
 
+    printSummary(result);
     process.exitCode = result.exitReason === "error" ? 1 : 0;
   },
 };

--- a/packages/cli/src/ui/ralph-app.tsx
+++ b/packages/cli/src/ui/ralph-app.tsx
@@ -21,7 +21,11 @@ import { RALPH_ICON } from "#global";
 import { createHookExecutor } from "#hooks";
 import { createParser, type OutputFormat, type ParsedChunk } from "#parsers";
 import type { ResultMessage, RichMessage } from "#parsers/message-types";
-import { isResultMessage } from "#parsers/message-types";
+import {
+  isMessage,
+  isResultMessage,
+  isToolUseBlock,
+} from "#parsers/message-types";
 import { type PrdFeature, validatePrd } from "#schema/prd";
 import { MessageList } from "#ui/components/message-list";
 import { type PassFilter, PrdItemsTab } from "#ui/components/prd-items-tab";
@@ -39,6 +43,10 @@ export interface LoopResult {
   exitReason: "complete" | "max_iterations" | "error" | "user_abort";
   lastExitCode: number;
   lastSessionId?: string;
+  totalInputTokens?: number;
+  totalOutputTokens?: number;
+  totalCost?: number;
+  toolCallCount?: number;
 }
 
 export interface RalphAppProps {
@@ -209,6 +217,7 @@ function RalphApp(props: RalphAppProps) {
   const [totalInputTokens, setTotalInputTokens] = createSignal(0);
   const [totalOutputTokens, setTotalOutputTokens] = createSignal(0);
   const [totalCost, setTotalCost] = createSignal(0);
+  const [toolCallCount, setToolCallCount] = createSignal(0);
   const spinnerChars = ["⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏"];
 
   // Tab view state
@@ -319,6 +328,10 @@ function RalphApp(props: RalphAppProps) {
       exitReason: "user_abort",
       lastExitCode: 130,
       lastSessionId: lastSessionId(),
+      totalInputTokens: totalInputTokens(),
+      totalOutputTokens: totalOutputTokens(),
+      totalCost: totalCost(),
+      toolCallCount: toolCallCount(),
     });
     renderer.destroy();
   };
@@ -428,24 +441,31 @@ function RalphApp(props: RalphAppProps) {
     props.showUsage &&
     (totalInputTokens() > 0 || totalOutputTokens() > 0 || totalCost() > 0);
 
+  const processRichMessage = (message: RichMessage) => {
+    setMessages((prev) => [...prev.slice(-OUTPUT_BUFFER_SIZE), message]);
+
+    if (isMessage(message)) {
+      const toolCalls = message.content.filter(isToolUseBlock);
+      if (toolCalls.length > 0) {
+        setToolCallCount((prev) => prev + toolCalls.length);
+      }
+    }
+
+    if (isResultMessage(message)) {
+      const result = message as ResultMessage;
+      if (result.usage) {
+        setTotalInputTokens((prev) => prev + result.usage!.input_tokens);
+        setTotalOutputTokens((prev) => prev + result.usage!.output_tokens);
+      }
+      if (result.total_cost_usd !== undefined) {
+        setTotalCost((prev) => prev + result.total_cost_usd!);
+      }
+    }
+  };
+
   const handleChunk = (chunk: ParsedChunk) => {
     if (chunk.richMessage) {
-      setMessages((prev) => [
-        ...prev.slice(-OUTPUT_BUFFER_SIZE),
-        chunk.richMessage!,
-      ]);
-
-      // Aggregate token usage and costs from result messages
-      if (isResultMessage(chunk.richMessage)) {
-        const result = chunk.richMessage as ResultMessage;
-        if (result.usage) {
-          setTotalInputTokens((prev) => prev + result.usage!.input_tokens);
-          setTotalOutputTokens((prev) => prev + result.usage!.output_tokens);
-        }
-        if (result.total_cost_usd !== undefined) {
-          setTotalCost((prev) => prev + result.total_cost_usd!);
-        }
-      }
+      processRichMessage(chunk.richMessage);
     }
     if (chunk.displayText) {
       setLegacyOutput((prev) => [
@@ -573,6 +593,10 @@ function RalphApp(props: RalphAppProps) {
       exitReason: exitReason(),
       lastExitCode,
       lastSessionId: lastSessionId(),
+      totalInputTokens: totalInputTokens(),
+      totalOutputTokens: totalOutputTokens(),
+      totalCost: totalCost(),
+      toolCallCount: toolCallCount(),
     });
     renderer.destroy();
   };


### PR DESCRIPTION
Show a summary of actions taken and outcomes when the process finishes:
- Exit reason (success, error, abort, max iterations)
- Number of iterations completed
- Tool call count (when available)
- Token usage (input/output)
- Total cost
- Session ID for reference

Works in both TUI and plain modes by extending LoopResult interface to track token usage, cost, and tool calls throughout execution.