### PR TITLE
Add model selection argument and config

### DIFF
--- a/packages/cli/src/adapters/claude.ts
+++ b/packages/cli/src/adapters/claude.ts
@@ -10,6 +10,10 @@ export class ClaudeAdapter implements CLIAdapter {
   buildArgs(prompt: string, options: AdapterOptions): string[] {
     const args = ["claude", "--permission-mode", "acceptEdits"];
 
+    if (options.model) {
+      args.push("--model", options.model);
+    }
+
     if (options.outputFormat === "stream-json") {
       args.push("--output-format", "stream-json", "--verbose");
     }

--- a/packages/cli/src/adapters/opencode.ts
+++ b/packages/cli/src/adapters/opencode.ts
@@ -9,6 +9,9 @@ export class OpenCodeAdapter implements CLIAdapter {
 
   buildArgs(prompt: string, options: AdapterOptions): string[] {
     const args = ["opencode", "--non-interactive"];
+    if (options.model) {
+      args.push("--model", options.model);
+    }
     if (options.verbose) {
       args.push("--verbose");
     }

--- a/packages/cli/src/adapters/types.ts
+++ b/packages/cli/src/adapters/types.ts
@@ -4,6 +4,7 @@ export interface AdapterOptions {
   verbose?: boolean;
   cwd?: string;
   outputFormat?: OutputFormat;
+  model?: string;
 }
 
 export interface AdapterResult {

--- a/packages/cli/src/commands/run.ts
+++ b/packages/cli/src/commands/run.ts
@@ -4,6 +4,7 @@ import type { CommandModule } from "yargs";
 import { getAdapter } from "#adapters/index";
 import type { CLIAdapter } from "#adapters/types";
 import { getPromptPath, loadConfig } from "#config/loader";
+import { ALL_MODEL_CHOICES } from "#config/schema";
 import { createParser, type OutputFormat } from "#parsers";
 import type { LoopResult } from "#ui/ralph-app";
 import { runLoopTUI } from "#ui/ralph-app";
@@ -18,6 +19,7 @@ interface RunArgs {
   noTui?: boolean;
   outputFormat?: string;
   logFile?: string;
+  model?: string;
 }
 
 function resolvePrompt(promptArg: string | undefined, cwd: string): string {
@@ -65,9 +67,10 @@ async function runOnce(
   promptContent: string,
   cwd: string,
   verbose?: boolean,
-  outputFormat?: OutputFormat
+  outputFormat?: OutputFormat,
+  model?: string
 ): Promise<number> {
-  const args = adapter.buildArgs(promptContent, { verbose, cwd, outputFormat });
+  const args = adapter.buildArgs(promptContent, { verbose, cwd, outputFormat, model });
   const proc = Bun.spawn(args, {
     cwd,
     stdin: "inherit",
@@ -84,7 +87,8 @@ async function runLoopPlain(
   cwd: string,
   maxIterations: number,
   verbose?: boolean,
-  outputFormat: OutputFormat = "stream-json"
+  outputFormat: OutputFormat = "stream-json",
+  model?: string
 ): Promise<LoopResult> {
   let lastExitCode = 0;
   let iterations = 0;
@@ -99,6 +103,7 @@ async function runLoopPlain(
       verbose,
       cwd,
       outputFormat,
+      model,
     });
     const proc = Bun.spawn(args, {
       cwd,
@@ -224,6 +229,12 @@ export const runCommand: CommandModule<object, RunArgs> = {
         alias: "l",
         type: "string",
         describe: "Write raw stream-json output to file",
+      })
+      .option("model", {
+        alias: "m",
+        type: "string",
+        choices: ALL_MODEL_CHOICES,
+        describe: "Model to use for the adapter",
       }),
 
   handler: async (argv) => {
@@ -256,6 +267,7 @@ export const runCommand: CommandModule<object, RunArgs> = {
     }
 
     const verbose = argv.verbose ?? config.verbose;
+    const model = argv.model ?? config.model;
 
     // Single iteration mode
     if (argv.once) {
@@ -264,7 +276,8 @@ export const runCommand: CommandModule<object, RunArgs> = {
         promptContent,
         cwd,
         verbose,
-        outputFormat
+        outputFormat,
+        model
       );
       process.exit(exitCode);
     }
@@ -290,6 +303,7 @@ export const runCommand: CommandModule<object, RunArgs> = {
         adapter,
         outputFormat,
         logFile,
+        model,
       });
     } else {
       result = await runLoopPlain(
@@ -298,7 +312,8 @@ export const runCommand: CommandModule<object, RunArgs> = {
         cwd,
         maxIterations,
         verbose,
-        outputFormat
+        outputFormat,
+        model
       );
     }
 

--- a/packages/cli/src/config/schema.ts
+++ b/packages/cli/src/config/schema.ts
@@ -3,12 +3,44 @@ import { z } from "zod";
 export const AdapterType = z.enum(["claude", "opencode"]);
 export type AdapterType = z.infer<typeof AdapterType>;
 
+// Model types for Claude adapter
+export const ClaudeModelType = z.enum([
+  "claude-sonnet-4-20250514",
+  "claude-opus-4-5-20251101",
+  "claude-haiku-3-5-20241022",
+  "sonnet",
+  "opus",
+  "haiku",
+]);
+export type ClaudeModelType = z.infer<typeof ClaudeModelType>;
+
+// Model types for OpenCode adapter
+export const OpenCodeModelType = z.enum([
+  "gpt-4o",
+  "gpt-4o-mini",
+  "gpt-4-turbo",
+  "o1",
+  "o1-mini",
+]);
+export type OpenCodeModelType = z.infer<typeof OpenCodeModelType>;
+
+// Combined model type for CLI argument choices
+export const ModelType = z.union([ClaudeModelType, OpenCodeModelType]);
+export type ModelType = z.infer<typeof ModelType>;
+
+// All available model choices for CLI
+export const ALL_MODEL_CHOICES = [
+  ...ClaudeModelType.options,
+  ...OpenCodeModelType.options,
+] as const;
+
 export const ConfigSchema = z.object({
   adapter: AdapterType.default("claude"),
   plansDir: z.string().default(".plans"),
   maxIterations: z.number().int().positive().default(10),
   verbose: z.boolean().default(false),
   tui: z.boolean().default(true),
+  model: z.string().optional(),
 });
 
 export type Config = z.infer<typeof ConfigSchema>;
@@ -19,4 +51,5 @@ export const DEFAULT_CONFIG: Config = {
   maxIterations: 10,
   verbose: false,
   tui: true,
+  model: undefined,
 };

--- a/packages/cli/src/ui/ralph-app.tsx
+++ b/packages/cli/src/ui/ralph-app.tsx
@@ -35,6 +35,7 @@ export interface RalphAppProps {
   adapter: CLIAdapter;
   outputFormat?: OutputFormat;
   logFile?: string;
+  model?: string;
   onComplete: (result: LoopResult) => void;
 }
 
@@ -63,9 +64,10 @@ async function runIterationCapture(
   verbose: boolean | undefined,
   outputFormat: OutputFormat,
   onChunk: (chunk: ParsedChunk) => void,
-  logger?: JsonLogger
+  logger?: JsonLogger,
+  model?: string
 ): Promise<AdapterResult> {
-  const args = adapter.buildArgs(promptContent, { verbose, cwd, outputFormat });
+  const args = adapter.buildArgs(promptContent, { verbose, cwd, outputFormat, model });
   ctx.proc = Bun.spawn(args, {
     cwd,
     stdout: "pipe",
@@ -294,7 +296,8 @@ function RalphApp(props: RalphAppProps) {
           props.verbose,
           outputFormat,
           handleChunk,
-          logger
+          logger,
+          props.model
         );
 
         if (ctx.aborted) {


### PR DESCRIPTION
Add support for model selection via CLI argument and config:
- Define adapter-specific model types (ClaudeModelType, OpenCodeModelType)
- Add --model/-m CLI argument to run command with valid choices
- Add model field to config schema for persistent configuration
- Pass model through to adapters which use --model flag when building args