### PR TITLE
docs: sync docs and README with ACP migration

### DIFF
--- a/.ralph/config.toml
+++ b/.ralph/config.toml
@@ -2,5 +2,5 @@
 adapter = "claude"
 plansDir = ".plans"
 maxIterations = 10
-verbose = true
+debug = true
 tui = true

--- a/README.md
+++ b/README.md
@@ -53,11 +53,13 @@ npm i -g opencode-ai
 
 ### Supported Adapters
 
-| Adapter | Status |
-|---------|--------|
-| Claude Code | Complete |
-| OpenCode | Complete |
-| Gemini CLI | Under Development |
+| Adapter | Status | ACP Command |
+|---------|--------|-------------|
+| Claude Code | Complete | `claude-code-acp` |
+| OpenCode | Complete | `opencode acp` |
+| Gemini CLI | Under Development | `gemini --experimental-acp` |
+
+All adapters communicate via ACP (Agent Client Protocol).
 
 ## Quick Start
 
@@ -113,8 +115,10 @@ ralph uses TOML config at `.ralph/config.toml`:
 adapter = "claude"
 maxIterations = 20
 plansDir = ".plans"
-verbose = false
+debug = false
 tui = true
+yolo = false
+transportLog = false
 
 [hooks]
 ralph_start = ""
@@ -150,8 +154,9 @@ ralph check             # Validate prd.json schema
 ralph run --max-iterations 10   # Limit iterations
 ralph run --once                # Single iteration (no loop)
 ralph run --prompt TASK.md      # Use specific prompt file
-ralph run --no-tui              # Plain text output (for CI)
-ralph run --verbose             # Debug output
+ralph run --debug               # Write debug log to file
+ralph run --yolo                # Auto-approve all permissions
+ralph run --transport-log       # Log raw ACP transport messages
 ```
 
 ## Loop Prompt Example

--- a/packages/cli/docs/hooks.md
+++ b/packages/cli/docs/hooks.md
@@ -117,4 +117,4 @@ Each hook receives context via environment variables.
 - Hook failures (non-zero exit) are logged but don't stop Ralph
 - Hooks inherit the parent process environment
 - Commands run via `sh -c` in the configured working directory
-- Use `verbose: true` in config to see hook execution logs
+- Use `debug = true` in config to see hook execution logs

--- a/packages/cli/src/commands/run.test.ts
+++ b/packages/cli/src/commands/run.test.ts
@@ -3,11 +3,11 @@
  *
  * These tests validate the run command's logic and flag handling behavior.
  * The run command is the primary entry point for the agent loop and supports:
- * - TUI/plain text output modes (--no-tui flag)
  * - Iteration limits (--max-iterations, -n)
  * - Single run mode (--once, -o)
- * - Output format selection (--output-format, -f)
- * - Debug mode (--debug, -d)
+ * - Debug logging (--debug, -d)
+ * - Auto-approve permissions (--yolo, -y)
+ * - ACP transport logging (--transport-log, -t)
  *
  * Note: Direct import of runCommand is avoided because it pulls in JSX
  * components that don't work in the test environment. Instead, we test
@@ -19,72 +19,6 @@ import type { ParsedChunk } from "#parsers";
 import type { Message, ResultMessage } from "#parsers/message-types";
 import { trackTokensFromChunk } from "./run-helpers";
 
-describe("run command useTui logic", () => {
-  /**
-   * Tests the useTui calculation logic.
-   * useTui = config.tui && !argv.noTui
-   * This is the actual logic from run.ts:280
-   *
-   * This is critical to test because --no-tui must correctly
-   * disable TUI mode regardless of config setting.
-   */
-  test("useTui is false when noTui is true", () => {
-    const configTui = true;
-    const argvNoTui = true;
-
-    const useTui = configTui && !argvNoTui;
-    expect(useTui).toBe(false);
-  });
-
-  /**
-   * Tests that TUI is enabled when noTui is false/undefined.
-   * Default behavior should use TUI if config allows.
-   */
-  test("useTui is true when noTui is false/undefined", () => {
-    const configTui = true;
-    const argvNoTui = false;
-
-    const useTui = configTui && !argvNoTui;
-    expect(useTui).toBe(true);
-  });
-
-  /**
-   * Tests that config.tui=false disables TUI.
-   * Config setting should be respected.
-   */
-  test("useTui is false when config.tui is false", () => {
-    const configTui = false;
-    const argvNoTui = false;
-
-    const useTui = configTui && !argvNoTui;
-    expect(useTui).toBe(false);
-  });
-
-  /**
-   * Tests that both false still results in no TUI.
-   * Belt and suspenders check.
-   */
-  test("useTui is false when both config.tui false and noTui true", () => {
-    const configTui = false;
-    const argvNoTui = true;
-
-    const useTui = configTui && !argvNoTui;
-    expect(useTui).toBe(false);
-  });
-
-  /**
-   * Tests undefined noTui (flag not provided) with true config.
-   * Undefined should be treated as false (TUI enabled).
-   */
-  test("useTui is true when noTui is undefined and config.tui is true", () => {
-    const configTui = true;
-    const argvNoTui = undefined;
-
-    const useTui = configTui && !argvNoTui;
-    expect(useTui).toBe(true);
-  });
-});
-
 describe("run command flag interaction edge cases", () => {
   /**
    * Tests that --once and --max-iterations don't conflict.
@@ -93,45 +27,14 @@ describe("run command flag interaction edge cases", () => {
   test("once and maxIterations can both be set", () => {
     // In the handler: if (argv.once) runs single iteration
     // So --max-iterations is effectively ignored with --once
-    // This is acceptable behavior
     const once = true;
     const maxIterations = 10;
 
-    // Handler check
     if (once) {
-      // Single iteration mode - maxIterations ignored
       expect(true).toBe(true);
     } else {
-      // Loop mode uses maxIterations
       expect(maxIterations).toBe(10);
     }
-  });
-
-  /**
-   * Tests --no-tui with stream-json format.
-   * Even without TUI, stream-json provides structured output.
-   */
-  test("no-tui with stream-json uses plain output loop", () => {
-    const noTui = true;
-    const outputFormat = "stream-json";
-
-    // Handler runs runLoopPlain with stream-json parser
-    // This provides structured parsing even in plain mode
-    expect(noTui).toBe(true);
-    expect(outputFormat).toBe("stream-json");
-  });
-
-  /**
-   * Tests --no-tui with text format for simple output.
-   * Common CI/CD combination.
-   */
-  test("no-tui with text format for simple output", () => {
-    const noTui = true;
-    const outputFormat = "text";
-
-    // This combination gives the simplest output
-    expect(noTui).toBe(true);
-    expect(outputFormat).toBe("text");
   });
 });
 
@@ -140,20 +43,6 @@ describe("run command expected yargs options", () => {
    * Documents the expected option configuration for the run command.
    * These tests verify our understanding of how yargs should be configured.
    */
-
-  test("--no-tui should convert to noTui in argv", () => {
-    // Yargs converts --no-<flag> to <flag>: false OR
-    // if defined as boolean option named "no-tui", it becomes noTui: true
-    // This test documents the expected behavior
-    const expectedOptions = {
-      "no-tui": {
-        type: "boolean",
-        describe: "Disable TUI (plain text output)",
-      },
-    };
-
-    expect(expectedOptions["no-tui"].type).toBe("boolean");
-  });
 
   test("--max-iterations should be a number", () => {
     const expectedOptions = {
@@ -166,22 +55,6 @@ describe("run command expected yargs options", () => {
 
     expect(expectedOptions["max-iterations"].type).toBe("number");
     expect(expectedOptions["max-iterations"].alias).toBe("n");
-  });
-
-  test("--output-format should have choices", () => {
-    const expectedOptions = {
-      "output-format": {
-        alias: "f",
-        type: "string",
-        choices: ["stream-json", "opencode-json", "text"],
-        default: "stream-json",
-      },
-    };
-
-    expect(expectedOptions["output-format"].choices).toContain("stream-json");
-    expect(expectedOptions["output-format"].choices).toContain("opencode-json");
-    expect(expectedOptions["output-format"].choices).toContain("text");
-    expect(expectedOptions["output-format"].default).toBe("stream-json");
   });
 
   test("--once should be a boolean", () => {
@@ -208,6 +81,32 @@ describe("run command expected yargs options", () => {
 
     expect(expectedOptions.debug.type).toBe("boolean");
     expect(expectedOptions.debug.alias).toBe("d");
+  });
+
+  test("--yolo should be a boolean", () => {
+    const expectedOptions = {
+      yolo: {
+        alias: "y",
+        type: "boolean",
+        describe: "Auto-approve all permission requests",
+      },
+    };
+
+    expect(expectedOptions.yolo.type).toBe("boolean");
+    expect(expectedOptions.yolo.alias).toBe("y");
+  });
+
+  test("--transport-log should be a boolean", () => {
+    const expectedOptions = {
+      "transport-log": {
+        alias: "t",
+        type: "boolean",
+        describe: "Enable raw ACP transport logging to file",
+      },
+    };
+
+    expect(expectedOptions["transport-log"].type).toBe("boolean");
+    expect(expectedOptions["transport-log"].alias).toBe("t");
   });
 });
 

--- a/packages/docs/astro.config.mjs
+++ b/packages/docs/astro.config.mjs
@@ -122,6 +122,12 @@ export default defineConfig({
           { label: "FAQ", slug: "reference/faq" },
         ],
       },
+      {
+        label: "What's New",
+        items: [
+          { label: "ACP Support", slug: "announcements/acp" },
+        ],
+      },
     ],
     components: {
       Hero: "./src/components/Hero.astro",

--- a/packages/docs/src/content/docs/announcements/acp.mdx
+++ b/packages/docs/src/content/docs/announcements/acp.mdx
@@ -1,0 +1,58 @@
+---
+title: ACP Support
+description: Ralph now uses the Agent Client Protocol (ACP) for all agent communication, bringing interactive permissions, session continuity, and broader agent support.
+---
+
+import { Aside } from '@astrojs/starlight/components';
+
+Ralph's agent communication layer has been rebuilt around the **Agent Client Protocol (ACP)** — a standard JSON-RPC protocol over stdio. All adapters now speak the same protocol, which makes the integration more reliable and opens the door to supporting more agents.
+
+---
+
+## Expanded agent support
+
+Three adapters are available, all using ACP:
+
+| Adapter | Command |
+|---------|---------|
+| Claude Code | `claude-code-acp` |
+| OpenCode | `opencode acp` |
+| Gemini (experimental) | `gemini --experimental-acp` |
+
+Because adapters share a common protocol, adding support for new agents is now straightforward.
+
+---
+
+## Interactive permission handling
+
+Agents now request permission for specific tool calls at runtime. A modal appears in the TUI showing the tool name, the kind of access requested, and numbered options to allow or deny.
+
+Permissions work in three ways:
+
+- **Interactive** — press a number key to allow or deny each request
+- **Cached** — `allow_always` selections are remembered for the rest of the session
+- **Unattended** — run with `--yolo` to auto-approve all requests without prompting
+
+```bash
+ralph run --yolo   # auto-approve all permissions
+```
+
+---
+
+## Session continuity
+
+Each run now has a session ID. If a run is interrupted, Claude Code and OpenCode sessions can be resumed — either by ralph itself on the next iteration, or by opening the session directly in the native CLI tool from the TUI.
+
+---
+
+## New flags
+
+Three new flags were added alongside this change:
+
+| Flag | Description |
+|------|-------------|
+| `--debug` / `-d` | Write a `ralph-debug-<timestamp>.log` file |
+| `--yolo` / `-y` | Auto-approve all permission requests |
+| `--transport-log` / `-t` | Write raw ACP protocol messages to a log file |
+
+All three can also be set persistently in `.ralph/config.toml`. See the [CLI reference](/usage/cli/) and [configuration](/usage/configuration/) for details.

--- a/packages/docs/src/content/docs/index.mdx
+++ b/packages/docs/src/content/docs/index.mdx
@@ -5,6 +5,8 @@ template: splash
 hero:
   tagline: The AI coding loop that keeps going until it's done.
   actions: []
+banner:
+  content: 'ACP support is here — more agents, interactive permissions, session continuity. <a href="/announcements/acp">Read the announcement →</a>'
 ---
 
 import { Card, CardGrid } from '@astrojs/starlight/components';

--- a/packages/docs/src/content/docs/reference/architecture.mdx
+++ b/packages/docs/src/content/docs/reference/architecture.mdx
@@ -223,11 +223,13 @@ project/
 interface Config {
   adapter: 'claude' | 'opencode' | 'gemini';
   plansDir: string;
-  maxIterations: number;
-  verbose: boolean;
+  maxIterations?: number;
+  debug: boolean;
   tui: boolean;
   showUsage: boolean;
-  hooks: {
+  yolo: boolean;
+  transportLog: boolean;
+  hooks?: {
     ralph_start?: string;
     ralph_loop_start?: string;
     ralph_loop_end?: string;

--- a/packages/docs/src/content/docs/usage/cli.mdx
+++ b/packages/docs/src/content/docs/usage/cli.mdx
@@ -26,11 +26,10 @@ ralph run [options]
 | `--max-iterations` | `-n` | number | Maximum loop iterations (default from config) |
 | `--once` | `-o` | boolean | Run single iteration (no loop) |
 | `--prompt` | `-p` | string | Prompt text or path to prompt file |
-| `--cwd` | `-c` | string | Working directory |
-| `--verbose` | `-v` | boolean | Enable verbose output |
-| `--no-tui` | - | boolean | Disable TUI (plain text output) |
-| `--output-format` | `-f` | string | Output format: `stream-json`, `opencode-json`, `text` |
-| `--log-file` | `-l` | string | Write raw stream-json output to file |
+| `--cwd` | `-c` | string | Working directory (default: current directory) |
+| `--debug` | `-d` | boolean | Enable debug logging to file |
+| `--yolo` | `-y` | boolean | Auto-approve all permission requests |
+| `--transport-log` | `-t` | boolean | Enable raw ACP transport logging to file |
 
 **Examples:**
 
@@ -47,11 +46,14 @@ ralph run --once
 # Limit iterations
 ralph run --max-iterations 5
 
-# Verbose output for debugging
-ralph run -v
+# Enable debug logging to file
+ralph run --debug
 
-# Disable TUI for CI/plain output
-ralph run --no-tui
+# Auto-approve all permission requests (unattended use)
+ralph run --yolo
+
+# Log raw ACP transport messages
+ralph run --transport-log
 ```
 
 **Exit Reasons:**

--- a/packages/docs/src/content/docs/usage/configuration.mdx
+++ b/packages/docs/src/content/docs/usage/configuration.mdx
@@ -29,14 +29,20 @@ plansDir = ".plans"
 # Maximum iterations before stopping
 maxIterations = 10
 
-# Enable verbose output
-verbose = false
+# Enable debug logging to file
+debug = false
 
 # Enable Terminal UI
 tui = true
 
 # Show token usage info
 showUsage = false
+
+# Auto-approve all permission requests
+yolo = false
+
+# Enable raw ACP transport logging to file
+transportLog = false
 
 # Lifecycle hooks (shell commands)
 [hooks]
@@ -83,13 +89,13 @@ Safety limit on loop iterations. ralph stops when this limit is reached, even if
 Always keep a reasonable `maxIterations` value to prevent runaway API costs.
 </Aside>
 
-### Verbose Mode
+### Debug Mode
 
 ```toml
-verbose = false
+debug = false
 ```
 
-Enable detailed output for debugging.
+Enable debug logging. When `true`, ralph writes a timestamped `ralph-debug-<timestamp>.log` file in the working directory.
 
 ### Terminal UI
 

--- a/packages/docs/src/content/docs/usage/hooks.mdx
+++ b/packages/docs/src/content/docs/usage/hooks.mdx
@@ -173,7 +173,7 @@ git commit -m "ralph: iteration $RALPH_LOOP_ITERATION" --allow-empty || true
 
 - Hook failures (non-zero exit code) are logged but **don't stop Ralph**
 - Use `|| true` to suppress expected failures
-- Enable `verbose = true` in config to see hook execution logs
+- Enable `debug = true` in config to see hook execution logs
 
 <Aside type="caution" title="Long-Running Hooks">
 Hooks block the loop. Avoid long-running commands in `ralph_loop_start` or `ralph_loop_end` as they run every iteration.
@@ -181,16 +181,16 @@ Hooks block the loop. Avoid long-running commands in `ralph_loop_start` or `ralp
 
 ### Debugging
 
-Enable verbose mode to see hook execution:
+Enable debug mode to see hook execution:
 
 ```toml
-verbose = true
+debug = true
 ```
 
 Or via CLI:
 
 ```bash
-ralph run --verbose
+ralph run --debug
 ```
 
 ---


### PR DESCRIPTION
## Summary

- Update CLI reference, configuration, hooks, architecture, and README to reflect ACP migration: rename `verbose` → `debug`, remove `--no-tui`/`--output-format`/`--log-file`, add `--debug`/`--yolo`/`--transport-log` and `yolo`/`transportLog` config keys
- Remove stale `useTui`/`--no-tui`/`--output-format` tests; add tests for `--yolo` and `--transport-log`
- Add ACP announcement page (`/announcements/acp`) covering expanded adapter support, interactive permissions, session continuity, and new flags
- Add homepage banner linking to announcement; add "What's New" sidebar group