### PR TITLE
fix(build): surface Bun.build errors instead of silently continuing

### DIFF
--- a/packages/cli/script/build.ts
+++ b/packages/cli/script/build.ts
@@ -125,7 +125,7 @@ for (const item of targets) {
   console.log(`building ${name}`);
   await $`mkdir -p dist/${dirName}/bin`;
 
-  await Bun.build({
+  const result = await Bun.build({
     target: "bun",
     tsconfig: "./tsconfig.json",
     plugins: [solidPlugin],
@@ -141,6 +141,14 @@ for (const item of targets) {
     },
     entrypoints: ["./src/index.ts"],
   });
+
+  if (!result.success) {
+    console.error(`Build failed for ${name}:`);
+    for (const log of result.logs) {
+      console.error(log);
+    }
+    process.exit(1);
+  }
 
   // Generate platform-specific package.json for npm publishing
   const platformPkg = {


### PR DESCRIPTION
## Summary
- `Bun.build()` returns `{ success: false }` on failure rather than throwing — previously errors were silently ignored
- The smoke test in `publish.ts` then failed with misleading "command not found" because no binary was produced
- Now logs all build errors and exits non-zero so the real compile failure is visible in CI